### PR TITLE
Actually restrict H.OPE. access

### DIFF
--- a/src/main/java/com/hedvig/backoffice/security/GatekeeperFilter.kt
+++ b/src/main/java/com/hedvig/backoffice/security/GatekeeperFilter.kt
@@ -24,7 +24,11 @@ class GatekeeperFilter(
           SecurityContextHolder.getContext().authentication = null
         } else {
           val tokenInfo = gatekeeper.tokenInfo("Bearer $accessToken")
-          SecurityContextHolder.getContext().authentication = GatekeeperAuthentication(tokenInfo, accessToken)
+          if (tokenInfo.scopes.contains("hope:read")) {
+            SecurityContextHolder.getContext().authentication = GatekeeperAuthentication(tokenInfo, accessToken)
+          } else {
+            logger.warn("User ${tokenInfo.subject} tried to access hope but is lacking the \"hope:read\" scope")
+          }
         }
       } catch (e: ExternalServiceUnauthorizedException) {
         // we're not authenticated


### PR DESCRIPTION
Just wanted to make a point of how easy it becomes to restrict the access to hope. If we're fine with granting access to others via the gatekeeper DB for now, this is sufficient in a first step.