### PR TITLE
Send dashboard numbers via graphql

### DIFF
--- a/src/main/java/com/hedvig/backoffice/graphql/resolvers/GraphQLQuery.java
+++ b/src/main/java/com/hedvig/backoffice/graphql/resolvers/GraphQLQuery.java
@@ -7,6 +7,7 @@ import com.hedvig.backoffice.graphql.dataloaders.ClaimLoader;
 import com.hedvig.backoffice.graphql.dataloaders.MemberLoader;
 import com.hedvig.backoffice.graphql.types.*;
 import com.hedvig.backoffice.graphql.types.account.SchedulerStatus;
+import com.hedvig.backoffice.graphql.types.dashboard.DashboardNumbers;
 import com.hedvig.backoffice.graphql.types.itemizer.ItemCategory;
 import com.hedvig.backoffice.graphql.types.itemizer.ItemCategoryKind;
 import com.hedvig.backoffice.graphql.types.questions.QuestionGroupType;
@@ -28,6 +29,8 @@ import com.hedvig.backoffice.services.questions.QuestionService;
 import com.hedvig.backoffice.services.tickets.TicketService;
 import com.hedvig.backoffice.services.tickets.dto.TicketDto;
 import com.hedvig.backoffice.services.tickets.dto.TicketHistoryDto;
+import com.hedvig.backoffice.services.updates.UpdateType;
+import com.hedvig.backoffice.services.updates.UpdatesService;
 import graphql.schema.DataFetchingEnvironment;
 import org.springframework.stereotype.Component;
 
@@ -52,6 +55,7 @@ public class GraphQLQuery implements GraphQLQueryResolver {
   private final AutoAnswerSuggestionService autoAnswerSuggestionService;
   private final ChatServiceV2 chatServiceV2;
   private final QuestionService questionService;
+  private final UpdatesService updatesService;
 
   public GraphQLQuery(
     ProductPricingService productPricingService,
@@ -64,7 +68,8 @@ public class GraphQLQuery implements GraphQLQueryResolver {
     AutoAnswerSuggestionService autoAnswerSuggestionService,
     ChatServiceV2 chatServiceV2,
     QuestionService questionService,
-    ItemizerService itemizerService
+    ItemizerService itemizerService,
+    UpdatesService updatesService
   ) {
     this.productPricingService = productPricingService;
     this.memberLoader = memberLoader;
@@ -76,6 +81,7 @@ public class GraphQLQuery implements GraphQLQueryResolver {
     this.autoAnswerSuggestionService = autoAnswerSuggestionService;
     this.chatServiceV2 = chatServiceV2;
     this.questionService = questionService;
+    this.updatesService = updatesService;
   }
 
   public List<MonthlySubscription> monthlyPayments(YearMonth month) {
@@ -177,6 +183,12 @@ public class GraphQLQuery implements GraphQLQueryResolver {
 
   public List<PartnerResponseDto> getPartnerCampaignOwners() {
     return productPricingService.getPartnerCampaignOwners();
+  }
+
+  public DashboardNumbers getDashboardNumbers() {
+    Long claims = updatesService.get(UpdateType.CLAIMS);
+    Long questions = updatesService.get(UpdateType.QUESTIONS);
+    return new DashboardNumbers(claims, questions);
   }
 
   private String getToken(DataFetchingEnvironment env) {

--- a/src/main/java/com/hedvig/backoffice/graphql/types/dashboard/DashboardNumbers.kt
+++ b/src/main/java/com/hedvig/backoffice/graphql/types/dashboard/DashboardNumbers.kt
@@ -1,0 +1,6 @@
+package com.hedvig.backoffice.graphql.types.dashboard
+
+data class DashboardNumbers(
+  val numberOfClaims: Long,
+  val numberOfQuestions: Long
+)

--- a/src/main/java/com/hedvig/backoffice/services/updates/UpdatesService.java
+++ b/src/main/java/com/hedvig/backoffice/services/updates/UpdatesService.java
@@ -8,6 +8,8 @@ public interface UpdatesService {
 
   void set(long count, UpdateType type);
 
+  Long get(UpdateType type);
+
   void updates(String personnelEmail);
 
   void subscribe(String personnelEmail, String sessionId) throws AuthorizationException;

--- a/src/main/java/com/hedvig/backoffice/services/updates/UpdatesServiceImpl.java
+++ b/src/main/java/com/hedvig/backoffice/services/updates/UpdatesServiceImpl.java
@@ -87,6 +87,17 @@ public class UpdatesServiceImpl implements UpdatesService {
 
   @Override
   @Transactional
+  public Long get(UpdateType type) {
+    List<Updates> updates = updatesRepository.findByType(type);
+    if (updates.size() == 0) {
+      return 0L;
+    } else {
+      return updates.get(0).getCount();
+    }
+  }
+
+  @Override
+  @Transactional
   public void updates(String personnelEmail) {
     List<Updates> updates = updatesRepository.findByPersonnelEmail(personnelEmail);
     send(personnelEmail, updates);

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -20,6 +20,12 @@ type QueryType {
   claimItems(claimId: ID!): [ClaimItem!]!
   findPartnerCampaigns(input: CampaignFilter!): [VoucherCampaign!]!
   getPartnerCampaignOwners: [CampaignOwnerPartner!]!
+  dashboardNumbers: DashboardNumbers
+}
+
+type DashboardNumbers {
+  numberOfClaims: Int!
+  numberOfQuestions: Int!
 }
 
 type MutationType {


### PR DESCRIPTION
The primary goal of this is to be able to kill all sockets by using GraphQL instead, not to refactor how we get the numbers themselves. That is for a v2 of the refactoring steps.