### PR TITLE
Add default UnknownIncentive for IncentiveDto

### DIFF
--- a/src/main/java/com/hedvig/backoffice/services/product_pricing/dto/IncentiveDto.kt
+++ b/src/main/java/com/hedvig/backoffice/services/product_pricing/dto/IncentiveDto.kt
@@ -6,7 +6,7 @@ import com.hedvig.backoffice.graphql.UnionType
 import java.math.BigDecimal
 import javax.money.MonetaryAmount
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", defaultImpl = UnknownIncentive::class)
 @JsonSubTypes(
   JsonSubTypes.Type(value = MonthlyPercentageDiscountFixedPeriod::class, name = "MonthlyPercentageDiscountFixedPeriod"),
   JsonSubTypes.Type(value = FreeMonths::class, name = "FreeMonths"),
@@ -46,5 +46,10 @@ data class IndefinitePercentageDiscount(
 
 @UnionType
 data class VisibleNoDiscount(
+  val `_`: Boolean = true
+): IncentiveDto()
+
+@UnionType
+data class UnknownIncentive(
   val `_`: Boolean = true
 ): IncentiveDto()

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -472,15 +472,6 @@ type CampaignOwnerPartner {
   partnerId: String!
 }
 
-enum IncentiveType {
-  COST_DEDUCTION
-  FREE_MONTHS
-  NO_DISCOUNT
-  MONTHLY_PERCENTAGE_DISCOUNT_FIXED_PERIOD
-  INDEFINITE_PERCENTAGE_DISCOUNT
-  VISIBLE_NO_DISCOUNT
-}
-
 type VoucherCampaign {
   id: ID!
   campaignCode: String!

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -516,7 +516,11 @@ type VisibleNoDiscount {
   _: Boolean
 }
 
-union Incentive = MonthlyPercentageDiscountFixedPeriod | FreeMonths | CostDeduction | NoDiscount | IndefinitePercentageDiscount | VisibleNoDiscount
+type UnknownIncentive {
+  _: Boolean
+}
+
+union Incentive = MonthlyPercentageDiscountFixedPeriod | FreeMonths | CostDeduction | NoDiscount | IndefinitePercentageDiscount | VisibleNoDiscount | UnknownIncentive
 
 type ItemFamily implements ItemCategoryCore {
   id: ID!


### PR DESCRIPTION
When IncentiveDto can't be mapped, default to UnknownIncentive instead of throwing exception