### PR TITLE
Correctly return null if no NumberFailedCharges found in account-service

### DIFF
--- a/src/main/java/com/hedvig/backoffice/graphql/resolvers/MemberResolver.kt
+++ b/src/main/java/com/hedvig/backoffice/graphql/resolvers/MemberResolver.kt
@@ -128,8 +128,9 @@ class MemberResolver(
         }
     }
 
-    fun getNumberFailedCharges(member: Member): NumberFailedCharges {
-        return NumberFailedCharges.from(accountService.getNumberFailedCharges(member.memberId))
+    fun getNumberFailedCharges(member: Member): NumberFailedCharges? {
+        val numberFailedCharges = accountService.getNumberFailedCharges(member.memberId) ?: return null
+        return NumberFailedCharges.from(numberFailedCharges)
     }
 
     fun getTotalNumberOfClaims(member: Member, env: DataFetchingEnvironment): Int {

--- a/src/main/java/com/hedvig/backoffice/graphql/types/account/NumberFailedCharges.kt
+++ b/src/main/java/com/hedvig/backoffice/graphql/types/account/NumberFailedCharges.kt
@@ -4,13 +4,13 @@ import com.hedvig.backoffice.services.account.dto.NumberFailedChargesDto
 import java.time.Instant
 
 data class NumberFailedCharges(
-  val numberFailedCharges: Int,
-  val lastFailedChargeAt: Instant?
+    val numberFailedCharges: Int,
+    val lastFailedChargeAt: Instant?
 ) {
-  companion object {
-    fun from(numberFailedCharges: NumberFailedChargesDto) = NumberFailedCharges(
-      numberFailedCharges = numberFailedCharges.numberFailedCharges,
-      lastFailedChargeAt = numberFailedCharges.lastFailedChargeAt
-    )
-  }
+    companion object {
+        fun from(numberFailedCharges: NumberFailedChargesDto) = NumberFailedCharges(
+            numberFailedCharges = numberFailedCharges.numberFailedCharges,
+            lastFailedChargeAt = numberFailedCharges.lastFailedChargeAt
+        )
+    }
 }

--- a/src/main/java/com/hedvig/backoffice/services/account/AccountService.kt
+++ b/src/main/java/com/hedvig/backoffice/services/account/AccountService.kt
@@ -12,7 +12,7 @@ interface AccountService {
     fun backfillSubscriptions(memberId: String, backfilledBy: String)
     fun subscriptionSchedulesAwaitingApproval(status: ChargeStatus): List<SchedulerStateDto>
     fun addApprovedSubscriptions(requestBody: List<ApproveChargeRequestDto>, approvedBy: String)
-    fun getNumberFailedCharges(memberId: String): NumberFailedChargesDto
+    fun getNumberFailedCharges(memberId: String): NumberFailedChargesDto?
     fun getMonthlyEntriesForMember(memberId: String): List<MonthlyEntryDto>
     fun removeMonthlyEntry(id: UUID, removedBy: String)
 }

--- a/src/main/java/com/hedvig/backoffice/services/account/AccountServiceClient.kt
+++ b/src/main/java/com/hedvig/backoffice/services/account/AccountServiceClient.kt
@@ -3,6 +3,7 @@ package com.hedvig.backoffice.services.account
 import com.hedvig.backoffice.config.feign.FeignConfig
 import com.hedvig.backoffice.services.account.dto.*
 import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.util.*
 
@@ -43,7 +44,7 @@ interface AccountServiceClient {
     )
 
     @GetMapping("/_/numberFailedCharges/{memberId}")
-    fun getNumberFailedCharges(@PathVariable memberId: String): NumberFailedChargesDto
+    fun getNumberFailedCharges(@PathVariable memberId: String): ResponseEntity<NumberFailedChargesDto>
 
     @PostMapping("/_/schedule/subscription/backfill/{memberId}")
     fun backfillSubscriptions(

--- a/src/main/java/com/hedvig/backoffice/services/account/AccountServiceImpl.kt
+++ b/src/main/java/com/hedvig/backoffice/services/account/AccountServiceImpl.kt
@@ -3,6 +3,7 @@ package com.hedvig.backoffice.services.account
 import com.hedvig.backoffice.graphql.types.account.AccountEntryInput
 import com.hedvig.backoffice.graphql.types.account.MonthlyEntryInput
 import com.hedvig.backoffice.services.account.dto.*
+import org.springframework.http.HttpStatus
 import java.util.*
 
 class AccountServiceImpl(private val accountServiceClient: AccountServiceClient) : AccountService {
@@ -22,8 +23,14 @@ class AccountServiceImpl(private val accountServiceClient: AccountServiceClient)
     override fun addApprovedSubscriptions(requestBody: List<ApproveChargeRequestDto>, approvedBy: String) =
         accountServiceClient.addApprovedSubscriptions(requestBody, approvedBy)
 
-    override fun getNumberFailedCharges(memberId: String): NumberFailedChargesDto =
-        accountServiceClient.getNumberFailedCharges(memberId)
+    override fun getNumberFailedCharges(memberId: String): NumberFailedChargesDto? {
+        val response = accountServiceClient.getNumberFailedCharges(memberId)
+        if (response.statusCode == HttpStatus.NOT_FOUND) {
+            return null
+        }
+        return response.body
+    }
+
 
     override fun backfillSubscriptions(memberId: String, backfilledBy: String) =
         accountServiceClient.backfillSubscriptions(memberId, backfilledBy)


### PR DESCRIPTION
## What?
- Return null if no member/number failed charges found in account-service

## Why?
- So we can safely ask for numberFailedCharges for non-signed members/those without an account