### PR TITLE
Catch 404 exception instead of checking uncheckable status

### DIFF
--- a/src/main/java/com/hedvig/backoffice/config/feign/FeignConfig.java
+++ b/src/main/java/com/hedvig/backoffice/config/feign/FeignConfig.java
@@ -35,15 +35,15 @@ public class FeignConfig {
       }
 
       if (status == HttpStatus.NOT_FOUND) {
-        return new ExternalServiceNotFoundException("entity not found", buff.toString());
+        return new ExternalServiceNotFoundException("FeignConfig (404): Entity not found", buff.toString());
       }
 
       if (status == HttpStatus.UNAUTHORIZED) {
-        return new ExternalServiceUnauthorizedException("unauthorized", buff.toString());
+        return new ExternalServiceUnauthorizedException("FeignConfig (403): Unauthorized", buff.toString());
       }
 
       if (status.is4xxClientError()) {
-        return new ExternalServiceBadRequestException("bad request", buff.toString());
+        return new ExternalServiceBadRequestException("FeignConfig (4XX): Bad request", buff.toString());
       }
 
       log.error(buff.toString());

--- a/src/main/java/com/hedvig/backoffice/services/account/AccountServiceClient.kt
+++ b/src/main/java/com/hedvig/backoffice/services/account/AccountServiceClient.kt
@@ -44,7 +44,7 @@ interface AccountServiceClient {
     )
 
     @GetMapping("/_/numberFailedCharges/{memberId}")
-    fun getNumberFailedCharges(@PathVariable memberId: String): ResponseEntity<NumberFailedChargesDto>
+    fun getNumberFailedCharges(@PathVariable memberId: String): NumberFailedChargesDto
 
     @PostMapping("/_/schedule/subscription/backfill/{memberId}")
     fun backfillSubscriptions(

--- a/src/main/java/com/hedvig/backoffice/services/account/AccountServiceImpl.kt
+++ b/src/main/java/com/hedvig/backoffice/services/account/AccountServiceImpl.kt
@@ -1,10 +1,16 @@
 package com.hedvig.backoffice.services.account
 
+import com.hedvig.backoffice.config.feign.ExternalServiceNotFoundException
 import com.hedvig.backoffice.graphql.types.account.AccountEntryInput
 import com.hedvig.backoffice.graphql.types.account.MonthlyEntryInput
-import com.hedvig.backoffice.services.account.dto.*
-import org.springframework.http.HttpStatus
-import java.util.*
+import com.hedvig.backoffice.services.account.dto.AccountDTO
+import com.hedvig.backoffice.services.account.dto.AccountEntryRequestDTO
+import com.hedvig.backoffice.services.account.dto.AddMonthlyEntryRequest
+import com.hedvig.backoffice.services.account.dto.ApproveChargeRequestDto
+import com.hedvig.backoffice.services.account.dto.MonthlyEntryDto
+import com.hedvig.backoffice.services.account.dto.NumberFailedChargesDto
+import com.hedvig.backoffice.services.account.dto.SchedulerStateDto
+import java.util.UUID
 
 class AccountServiceImpl(private val accountServiceClient: AccountServiceClient) : AccountService {
 
@@ -23,14 +29,11 @@ class AccountServiceImpl(private val accountServiceClient: AccountServiceClient)
     override fun addApprovedSubscriptions(requestBody: List<ApproveChargeRequestDto>, approvedBy: String) =
         accountServiceClient.addApprovedSubscriptions(requestBody, approvedBy)
 
-    override fun getNumberFailedCharges(memberId: String): NumberFailedChargesDto? {
-        val response = accountServiceClient.getNumberFailedCharges(memberId)
-        if (response.statusCode == HttpStatus.NOT_FOUND) {
-            return null
-        }
-        return response.body
+    override fun getNumberFailedCharges(memberId: String): NumberFailedChargesDto? = try {
+        accountServiceClient.getNumberFailedCharges(memberId)
+    } catch (exception: ExternalServiceNotFoundException) {
+        null
     }
-
 
     override fun backfillSubscriptions(memberId: String, backfilledBy: String) =
         accountServiceClient.backfillSubscriptions(memberId, backfilledBy)


### PR DESCRIPTION
## What?
- Catch 404 exception instead of checking the status

## Why?
- Because the exception is thrown instead of getting the ResponseEntity.

## Optional checklist
- [ ] Unit tests written
- [ ] Tested locally

