### PR TITLE
improve the dockerfile to be in charge of building and testing too, not just image assembly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,13 @@ COPY pom.xml /usr/src/app/
 RUN mvn -f /usr/src/app/pom.xml dependency:go-offline
 
 
-##### Compile stage #####
+##### Build stage #####
 FROM dependencies AS build
 
 COPY src/main /usr/src/app/src/main
 RUN mvn -f /usr/src/app/pom.xml clean package
 
-
-##### Test stage #####
-FROM dependencies AS test
-
 COPY src/test /usr/src/app/src/test
-COPY --from=build /usr/src/app/target /usr/src/app/target
 RUN mvn -f /usr/src/app/pom.xml test
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,12 @@ FROM dependencies AS build
 COPY src/main /usr/src/app/src/main
 RUN mvn -f /usr/src/app/pom.xml clean package
 
+
+##### Test stage #####
+FROM dependencies AS test
+
 COPY src/test /usr/src/app/src/test
+COPY --from=build /usr/src/app/target /usr/src/app/target
 RUN mvn -f /usr/src/app/pom.xml test
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,35 +7,28 @@ RUN mvn -f /usr/src/app/pom.xml dependency:go-offline
 
 
 ##### Compile stage #####
-FROM dependencies AS compile
+FROM dependencies AS build
 
 COPY src/main /usr/src/app/src/main
-RUN mvn -f /usr/src/app/pom.xml clean compile
+RUN mvn -f /usr/src/app/pom.xml clean package
 
 
 ##### Test stage #####
 FROM dependencies AS test
 
 COPY src/test /usr/src/app/src/test
-COPY --from=compile /usr/src/app/target /usr/src/app/target
+COPY --from=build /usr/src/app/target /usr/src/app/target
 RUN mvn -f /usr/src/app/pom.xml test
 
 
-##### Package stage #####
-FROM dependencies AS package
-
-COPY --from=compile /usr/src/app/target /usr/src/app/target
-RUN mvn -f /usr/src/app/pom.xml package
-
-
-##### Package artifact as runnable image #####
-FROM amazoncorretto:11 AS make_image
+##### Assemble artifact #####
+FROM amazoncorretto:11 AS assemble
 
 # Not sure what this one does
 RUN curl -o dd-java-agent.jar -L 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
 
 # Copy the jar from build stage to this one
-COPY --from=package /usr/src/app/target/back-office-0.0.1-SNAPSHOT.jar /usr/app/
+COPY --from=build /usr/src/app/target/back-office-0.0.1-SNAPSHOT.jar /usr/app/
 
 # Define entry point
 ENTRYPOINT java -javaagent:/dd-java-agent.jar -jar /usr/app/back-office-0.0.1-SNAPSHOT.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,19 @@ FROM maven:3.6.3-amazoncorretto-11 AS build
 COPY src /usr/src/app/src
 COPY pom.xml /usr/src/app/
 
+# Resolve dependencies and cache them
+RUN mvn -f /usr/src/app/pom.xml dependency:go-offline
 # Build and produce an artifact
-RUN mvn -f /usr/src/app/pom.xml clean package -Dmaven.javadoc.skip=true -B -V -e
+RUN mvn -f /usr/src/app/pom.xml clean install -DskipTests=true -Dmaven.javadoc.skip=true -V -e
+
+##### Test stage #####
+FROM maven:3.6.3-amazoncorretto-11 AS test
+
+COPY --from=build /usr/src/app/pom.xml /usr/src/app/
+RUN mvn -f /usr/src/app/pom.xml test
 
 ##### Package artifact as runnable image #####
-FROM amazoncorretto:11
+FROM amazoncorretto:11 AS make-image
 
 # Not sure what this one does
 RUN curl -o dd-java-agent.jar -L 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,22 @@
+
+##### Build stage #####
+FROM maven:3.6.3-amazoncorretto-11 AS build
+
+# Copy source folder and pom.xml to this stage
+COPY src /usr/src/app/src
+COPY pom.xml /usr/src/app/
+
+# Build and produce an artifact
+RUN mvn -f /usr/src/app/pom.xml clean package -Dmaven.javadoc.skip=true -B -V -e
+
+##### Package artifact as runnable image #####
 FROM amazoncorretto:11
 
+# Not sure what this one does
 RUN curl -o dd-java-agent.jar -L 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
 
-ADD target/back-office-0.0.1-SNAPSHOT.jar /
+# Copy the jar from build stage to this one
+COPY --from=build /usr/src/app/target/back-office-0.0.1-SNAPSHOT.jar /usr/app/
 
-ENTRYPOINT java -javaagent:/dd-java-agent.jar -jar back-office-0.0.1-SNAPSHOT.jar
+# Define entry point
+ENTRYPOINT java -javaagent:/dd-java-agent.jar -jar /usr/app/back-office-0.0.1-SNAPSHOT.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN mvn test
 ##### Assemble artifact #####
 FROM amazoncorretto:11 AS assemble
 
-# Not sure what this one does
+# Fetch the datadog agent
 RUN curl -o dd-java-agent.jar -L 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
 
 # Copy the jar from build stage to this one

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,23 +2,18 @@
 FROM maven:3.6.3-amazoncorretto-11 AS dependencies
 
 # Resolve dependencies and cache them
-COPY pom.xml /usr/src/app/
-RUN mvn -f /usr/src/app/pom.xml dependency:go-offline
+COPY pom.xml /
+RUN mvn dependency:go-offline
 
 
 ##### Build stage #####
 FROM dependencies AS build
 
-COPY src/main /usr/src/app/src/main
-RUN mvn -f /usr/src/app/pom.xml clean package
+COPY src/main /src/main
+RUN mvn clean package
 
-
-##### Test stage #####
-FROM dependencies AS test
-
-COPY src/test /usr/src/app/src/test
-COPY --from=build /usr/src/app/target /usr/src/app/target
-RUN mvn -f /usr/src/app/pom.xml test
+COPY src/test /src/test
+RUN mvn test
 
 
 ##### Assemble artifact #####
@@ -28,7 +23,7 @@ FROM amazoncorretto:11 AS assemble
 RUN curl -o dd-java-agent.jar -L 'https://repository.sonatype.org/service/local/artifact/maven/redirect?r=central-proxy&g=com.datadoghq&a=dd-java-agent&v=LATEST'
 
 # Copy the jar from build stage to this one
-COPY --from=build /usr/src/app/target/back-office-0.0.1-SNAPSHOT.jar /usr/app/
+COPY --from=build /target/back-office-0.0.1-SNAPSHOT.jar /
 
 # Define entry point
-ENTRYPOINT java -javaagent:/dd-java-agent.jar -jar /usr/app/back-office-0.0.1-SNAPSHOT.jar
+ENTRYPOINT java -javaagent:/dd-java-agent.jar -jar back-office-0.0.1-SNAPSHOT.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN mvn -f /usr/src/app/pom.xml dependency:go-offline
 ##### Build stage #####
 FROM maven AS build
 
-COPY src/main /usr/src/app/src/main
+COPY src /usr/src/app/src
 RUN mvn -f /usr/src/app/pom.xml clean package -Dmaven.javadoc.skip=true -V -e
 
 ##### Package artifact as runnable image #####

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ##### Setup Maven ####
-FROM maven:3.6.3-amazoncorretto-11 AS maven
+FROM maven:3.6.3-amazoncorretto-11 AS dependencies
 
 # Resolve dependencies and cache them
 COPY pom.xml /usr/src/app/
@@ -7,14 +7,14 @@ RUN mvn -f /usr/src/app/pom.xml dependency:go-offline
 
 
 ##### Compile stage #####
-FROM maven AS compile
+FROM dependencies AS compile
 
 COPY src/main /usr/src/app/src/main
 RUN mvn -f /usr/src/app/pom.xml clean compile
 
 
 ##### Test stage #####
-FROM maven AS test
+FROM dependencies AS test
 
 COPY src/test /usr/src/app/src/test
 COPY --from=compile /usr/src/app/target /usr/src/app/target
@@ -22,7 +22,7 @@ RUN mvn -f /usr/src/app/pom.xml test
 
 
 ##### Package stage #####
-FROM maven AS package
+FROM dependencies AS package
 
 COPY --from=compile /usr/src/app/target /usr/src/app/target
 RUN mvn -f /usr/src/app/pom.xml package

--- a/src/main/java/com/hedvig/backoffice/BackOfficeApplication.java
+++ b/src/main/java/com/hedvig/backoffice/BackOfficeApplication.java
@@ -45,7 +45,6 @@ public class BackOfficeApplication {
     for (Valve v : valves) {
       tomcat.addContextValves(v);
     }
-      System.out.println("")
     return tomcat;
   }
 

--- a/src/main/java/com/hedvig/backoffice/BackOfficeApplication.java
+++ b/src/main/java/com/hedvig/backoffice/BackOfficeApplication.java
@@ -45,7 +45,7 @@ public class BackOfficeApplication {
     for (Valve v : valves) {
       tomcat.addContextValves(v);
     }
-
+      System.out.println("")
     return tomcat;
   }
 

--- a/src/main/java/com/hedvig/backoffice/BackOfficeApplication.java
+++ b/src/main/java/com/hedvig/backoffice/BackOfficeApplication.java
@@ -45,6 +45,7 @@ public class BackOfficeApplication {
     for (Valve v : valves) {
       tomcat.addContextValves(v);
     }
+
     return tomcat;
   }
 


### PR DESCRIPTION
# Jira Issue: [HVG-902]

## What?
This makes the back-office `Dockerfile` able to not only assemble the image, but also **build and test it**. This enables us to have a non-java non-maven specific pipeline in Codefresh that can be reused for any service. 

## Why?
This makes wiring a service to Codefresh very simple, and makes the "how to build and test" a service part of the git repo.


## Optional checklist
- [ ] Unit tests written
- [x] Tested locally



[HVG-902]: https://hedvig.atlassian.net/browse/HVG-902