### PR TITLE
rely on the dependencyManagement declaration of spring cloud dependencies instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,17 +195,14 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-kubernetes</artifactId>
-      <version>0.3.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-kubernetes-config</artifactId>
-      <version>0.3.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-kubernetes-ribbon</artifactId>
-      <version>0.3.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.4.RELEASE</version>
+    <version>2.1.13.RELEASE</version>
     <relativePath/>
     <!-- lookup parent from repository -->
   </parent>
@@ -200,10 +200,12 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-kubernetes</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-kubernetes-config</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.cloud</groupId>
@@ -221,7 +223,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.0</version>
+      <version>1.18.4</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -368,7 +370,7 @@
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-test</artifactId>
+      <artifactId>kotlin-test-junit</artifactId>
       <version>${kotlin.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
-        <version>Finchley.SR4</version>
+        <version>Greenwich.SR5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
       <version>8.13.0</version>


### PR DESCRIPTION
# Jira Issue: [] 

## What?
Some spring cloud kubernetes dependencies were locked to a super old version, while there was also a `dependencyManagement` declaration for them. This removes the specific old versions to instead use the somewhat more modern one declared at the top of the pom.xml file.

## Why?
We're getting lots of error logs because of bugs in the old versions.

## Optional checklist
- [ ] Unit tests written
- [x] Tested locally

