### PR TITLE
get rid of (unused) TeeFilter to avoid stack trace vomit

### DIFF
--- a/src/main/java/com/hedvig/backoffice/config/LogBackAccess.java
+++ b/src/main/java/com/hedvig/backoffice/config/LogBackAccess.java
@@ -1,18 +1,12 @@
 package com.hedvig.backoffice.config;
 
 import ch.qos.logback.access.tomcat.LogbackValve;
-import javax.servlet.Filter;
 import org.apache.catalina.Valve;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class LogBackAccess {
-
-  @Bean(name = "TeeFilter")
-  public Filter teeFilter() {
-    return new ch.qos.logback.access.servlet.TeeFilter();
-  }
 
   @Bean
   public Valve logbackValve() {


### PR DESCRIPTION
# Jira Issue: [] 

## What?
- Remove `TeeFilter`, which gives functionality we don't really use 


## Why?
- `TeeFilter` has [a bug](https://jira.qos.ch/browse/LOGBACK-1527) in it that makes it print stack traces to stderr, which makes us unable to control its format. This causes Datadog to get massive piles of over-reported ERROR statements that drown out the real problems
- `TeeFilter` is used to retain body data for requests and responses so that can be printed. We don't actually use that data anyway, and they [even recommend you don't do that in production](http://logback.qos.ch/recipes/captureHttp.html#disabling)

## Optional checklist
- [ ] Codescouted
- [ ] Unit tests written
- [x] Tested locally

