### PR TITLE
Add handler reference to claim notes

### DIFF
--- a/src/main/java/com/hedvig/backoffice/graphql/GraphQLMutation.java
+++ b/src/main/java/com/hedvig/backoffice/graphql/GraphQLMutation.java
@@ -260,11 +260,12 @@ public class GraphQLMutation implements GraphQLMutationResolver {
         ClaimNoteInput input,
         DataFetchingEnvironment env
     ) throws AuthorizationException {
-        log.info("Personnell with email '{}' adding claim note",
-            GraphQLConfiguration.getEmail(env, personnelService));
+        final String employeeEmail = GraphQLConfiguration.getEmail(env, personnelService);
+        log.info("Personnell with email '{}' adding claim note", employeeEmail);
         val noteDto = new com.hedvig.backoffice.services.claims.dto.ClaimNote();
         noteDto.setText(input.getText());
         noteDto.setClaimID(id.toString());
+        noteDto.setHandlerReference(employeeEmail);
         claimsService.addNote(noteDto, GraphQLConfiguration.getIdToken(env, personnelService));
         return claimLoader.load(id);
     }

--- a/src/main/java/com/hedvig/backoffice/graphql/types/ClaimNote.java
+++ b/src/main/java/com/hedvig/backoffice/graphql/types/ClaimNote.java
@@ -8,8 +8,9 @@ import lombok.Value;
 public class ClaimNote {
   String text;
   LocalDateTime date;
+  String handlerReference;
 
   public static ClaimNote fromDTO(com.hedvig.backoffice.services.claims.dto.ClaimNote dto) {
-    return new ClaimNote(dto.getText(), dto.getDate());
+    return new ClaimNote(dto.getText(), dto.getDate(), dto.getHandlerReference());
   }
 }

--- a/src/main/java/com/hedvig/backoffice/services/claims/dto/ClaimNote.java
+++ b/src/main/java/com/hedvig/backoffice/services/claims/dto/ClaimNote.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class ClaimNote extends ClaimBackOffice {
-
   private String text;
   private String fileURL;
+  private String handlerReference; // Optional employee email
 }

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -969,6 +969,7 @@ type ClaimItemSet {
 type ClaimNote {
     text: String!
     date: LocalDateTime!
+    handlerReference: String
 }
 
 type ClaimTranscription {


### PR DESCRIPTION
# Jira Issue: [] 

## What?
- The back-office side of https://github.com/HedvigInsurance/claims-service/pull/100 and https://github.com/HedvigInsurance/claims-service/pull/99

## Why?
- So we can read claim note handler references and display them

## Optional checklist
- [ ] Unit tests written
- [x] Tested locally

