### PR TITLE
Turn off session management and apply some code styling

### DIFF
--- a/src/main/java/com/hedvig/backoffice/config/SecurityConfig.kt
+++ b/src/main/java/com/hedvig/backoffice/config/SecurityConfig.kt
@@ -18,27 +18,17 @@ class SecurityConfig @Autowired constructor(
 ) : WebSecurityConfigurerAdapter() {
     @Throws(Exception::class)
     override fun configure(http: HttpSecurity) {
-        http.cors()
-            .disable()
-            .csrf()
-            .disable()
+        http
+            .cors().disable()
+            .csrf().disable()
             .headers()
             .frameOptions()
             .disable()
             .and()
-            .sessionManagement()
-            .maximumSessions(1)
-            .and()
-            .and()
-            .addFilterBefore(
-              GatekeeperFilter(gatekeeperService), BasicAuthenticationFilter::class.java)
+            .addFilterBefore(GatekeeperFilter(gatekeeperService), BasicAuthenticationFilter::class.java)
             .authorizeRequests().antMatchers("/").permitAll().and()
-            .authorizeRequests()
-            .antMatchers("/api/**")
-            .authenticated()
-            .antMatchers("/chat/**")
-            .authenticated()
-            .antMatchers("/graphiql")
-            .authenticated();
+            .authorizeRequests().antMatchers("/api/**").authenticated()
+            .antMatchers("/chat/**").authenticated()
+            .antMatchers("/graphiql").authenticated();
     }
 }

--- a/src/main/java/com/hedvig/backoffice/security/GatekeeperFilter.kt
+++ b/src/main/java/com/hedvig/backoffice/security/GatekeeperFilter.kt
@@ -9,36 +9,29 @@ import javax.servlet.FilterChain
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-class GatekeeperFilter(
-  private val gatekeeper: GatekeeperService
-) : OncePerRequestFilter() {
-  override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, chain: FilterChain) {
-    val accessToken =
-      request.cookies?.find { cookie ->
-        cookie.name == "_hvg_at"
-      }?.value
+class GatekeeperFilter(private val gatekeeper: GatekeeperService) : OncePerRequestFilter() {
+    override fun doFilterInternal(request: HttpServletRequest, response: HttpServletResponse, chain: FilterChain) {
+        val accessToken = request.cookies?.find { cookie -> cookie.name == "_hvg_at" }?.value
 
-    accessToken.apply {
-      try {
-        if (accessToken == null) {
-          SecurityContextHolder.getContext().authentication = null
-        } else {
-          val tokenInfo = gatekeeper.tokenInfo("Bearer $accessToken")
-          if (tokenInfo.scopes.contains("hope:read")) {
-            SecurityContextHolder.getContext().authentication = GatekeeperAuthentication(tokenInfo, accessToken)
-          } else {
-            logger.warn("User ${tokenInfo.subject} tried to access hope but is lacking the \"hope:read\" scope")
-          }
+        try {
+            if (accessToken == null) {
+                SecurityContextHolder.getContext().authentication = null
+            } else {
+                val tokenInfo = gatekeeper.tokenInfo("Bearer $accessToken")
+                if (tokenInfo.scopes.contains("hope:read")) {
+                    SecurityContextHolder.getContext().authentication = GatekeeperAuthentication(tokenInfo, accessToken)
+                } else {
+                    logger.warn("User ${tokenInfo.subject} tried to access hope but is lacking the \"hope:read\" scope")
+                }
+            }
+        } catch (e: ExternalServiceUnauthorizedException) {
+            // we're not authenticated
+            SecurityContextHolder.getContext().authentication = null
+        } catch (e: ExternalServiceBadRequestException) {
+            // we're not authenticated
+            SecurityContextHolder.getContext().authentication = null
         }
-      } catch (e: ExternalServiceUnauthorizedException) {
-        // we're not authenticated
-        SecurityContextHolder.getContext().authentication = null
-      } catch (e: ExternalServiceBadRequestException) {
-        // we're not authenticated
-        SecurityContextHolder.getContext().authentication = null
-      }
-    }
 
-    chain.doFilter(request, response);
-  }
+        chain.doFilter(request, response);
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,14 +1,6 @@
 server:
   port: 8443
   httpPort: 8080
-  session:
-    cookie:
-      max-age: 3600
-      http-only: true
-      secure: true
-  servlet:
-    session:
-      timeout: 7200s
 
 logging:
   level:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,12 +1,6 @@
 server:
   port: 8443
   httpPort: 8080
-  session:
-    timeout: 3600
-    cookie:
-      max-age: 3600
-      http-only: true
-      secure: true
 
 logging:
   level:


### PR DESCRIPTION
# Jira Issue: [] 

## What?
- It seems we created a new session per request previously, causing strange issues when sending parallell requests. As Gateekeer is responsible for authentication, and auth is the only thing we used to use sessions for (afaik), we can now remove it. This should also kill off the error message we're getting in some requests ("_This session has been expired (possibly due to multiple concurrent logins being attempted as the same user)_").

## Why?


## Optional checklist
- [ ] Unit tests written
- [x] Tested locally

