### PR TITLE
Revert back to old graphql-commons in bintray.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,12 @@
       <url>https://jitpack.io</url>
     </repository>
     <repository>
-        <id>github</id>
-        <name>Hedvig GitHub Packages</name>
-        <url>https://maven.pkg.github.com/HedvigInsurance/libs</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>bintray-hedvig-hedvig-java</id>
+      <name>bintray</name>
+      <url>https://dl.bintray.com/hedvig/hedvig-java</url>
     </repository>
   </repositories>
 
@@ -295,7 +298,7 @@
     <dependency>
       <groupId>com.hedvig.graphql.commons</groupId>
       <artifactId>graphql-commons</artifactId>
-      <version>1.0.8</version>
+      <version>1.0.3</version>
       <exclusions>
         <exclusion>
           <artifactId>okhttp</artifactId>


### PR DESCRIPTION
Rolling back to `graphql-commons 1.0.3` due to an issue with upgrading to latest greatest `graphql-commons 1.0.8` causing:
```
Failed to parse configuration class [com.hedvig.backoffice.BackOfficeApplication]; nested exception is org.springframework.context.annotation.ConflictingBeanDefinitionException: Annotation-specified bean name 'URLScalar' for bean class [com.hedvig.graphql.commons.scalars.URLScalar] conflicts with existing, non-compatible bean definition of same name and class [com.hedvig.backoffice.graphql.scalars.URLScalar]
```
..at startup.

